### PR TITLE
Clarify licensing to GPLv2 for WP plugins/themes

### DIFF
--- a/_includes/markdown/Releasing.md
+++ b/_includes/markdown/Releasing.md
@@ -6,7 +6,7 @@ Aim for conceptual clarity over cleverness and puns. Creativity is good, but a n
 
 <h2 id="licensing" class="anchor-heading">Licensing {% include Util/link_anchor anchor="licensing" %} {% include Util/top %}</h2>
 
-At 10up, the vast majority of our open sourced code is released under the [MIT license](https://opensource.org/licenses/MIT), which is highly permissive and compatible with integration into GPL software such as WordPress. We recommend this route as a default but any other included libraries and integrations must also be taken into consideration before making a final licensing decision.
+At 10up, any project that is a WordPress plugin or theme should be licensed [GPLv2](https://opensource.org/licenses/GPL-2.0).  Standalone JavaScript libraries or modules can be licensed [MIT](https://opensource.org/licenses/MIT).  We recommend this route as a default, but any other included libraries and integrations must also be taken into consideration before making a final licensing decision.
 
 <h2 id="client-permissions" class="anchor-heading">Client permissions {% include Util/link_anchor anchor="client-permissions" %} {% include Util/top %}</h2>
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

The licensing section of the Releasing page was not clear enough that WordPress projects should be licensed GPLv2.  This PR attempts to better state that preference / recommendation.

### Alternate Designs

none

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

None identified

### Verification Process

Manually verified via GitHub web UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry
n/a
