### PR TITLE
Doc: Display test results in the GitHub Actions summary

### DIFF
--- a/_includes/markdown/Testing.md
+++ b/_includes/markdown/Testing.md
@@ -110,8 +110,7 @@ describe('Test Suite', ()={
 
 We utilize [the new Markdown support](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) of GH Actions summary to include the test results in the job summary.
 
-To generate the markdown report, we use [`mochawesome`](https://www.npmjs.com/package/cypress-mochawesome-reporter) reporter. The reporter generates JSON and HTML reports. We use `mochawesome` JSON reports by updating the cypress configuration as follows.
-
+To generate the markdown report, we use [`mochawesome`](https://www.npmjs.com/package/cypress-mochawesome-reporter) reporter to generate JSON and HTML reports. We use `mochawesome` JSON reports by updating the Cypress configuration as follows:
 
 ```javascript
 // tests/cypress/cypress-config.js 
@@ -129,7 +128,8 @@ module.exports = defineConfig({
 });
 ```
 
-Then, an additional step in the cypress workflow file to generate Markdown content from JSON reports and update it to GitHub Summary    
+Then, an additional step in the Cypress workflow file to generate Markdown content from JSON reports and update it to GitHub Summary:
+
 ```yaml
 # action.yml
 
@@ -143,4 +143,4 @@ Then, an additional step in the cypress workflow file to generate Markdown conte
     cat ./tests/cypress/reports/mochawesome.md >> $GITHUB_STEP_SUMMARY
 ```
 
-We configured to always update job summary by setting `if: ${{ always() }}`. If you wish to update summary when a job fails, then you can set it to `if: failure()`.
+We configure this to always update job summary by setting `if: ${{ always() }}`. If you wish to update the summary when a job fails, then you can set it to `if: failure()`.


### PR DESCRIPTION
### Description of the Change
PR Adds a small doc brief to Display E2E test results in the GitHub Actions summary



### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
