### PR TITLE
add GPL-compatible licensing action reference

### DIFF
--- a/_includes/markdown/Releasing.md
+++ b/_includes/markdown/Releasing.md
@@ -6,7 +6,7 @@ Aim for conceptual clarity over cleverness and puns. Creativity is good, but a n
 
 <h2 id="licensing" class="anchor-heading">Licensing {% include Util/link_anchor anchor="licensing" %} {% include Util/top %}</h2>
 
-At 10up, any project that is a WordPress plugin or theme should be licensed [GPLv2](https://opensource.org/licenses/GPL-2.0).  Standalone JavaScript libraries or modules can be licensed [MIT](https://opensource.org/licenses/MIT).  We recommend this route as a default, but any other included libraries and integrations must also be taken into consideration before making a final licensing decision.
+At 10up, any project that is a WordPress plugin or theme should be licensed [GPLv2](https://opensource.org/licenses/GPL-2.0).  Standalone JavaScript libraries or modules can be licensed [MIT](https://opensource.org/licenses/MIT).  We recommend this route as a default, but any other included libraries and integrations must also be taken into consideration before making a final licensing decision.  All plugin projects should leverage our [Dependency Review Action](https://github.com/10up/insert-special-characters/blob/develop/.github/workflows/dependency-review.yml) and [GPL-Compatible License Policy](https://github.com/10up/.github/blob/trunk/.github/dependency-review-config.yml) to ensure all plugin dependencies are GPL-compatible.
 
 <h2 id="client-permissions" class="anchor-heading">Client permissions {% include Util/link_anchor anchor="client-permissions" %} {% include Util/top %}</h2>
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR adds a reference to the Licensing section to link to our GitHub Action and GPL-compatible license policy for use on plugin projects to ensure all dependencies are GPL-compatible.

### How to test the Change

Use a markdown previewer

### Changelog Entry

> Added - GPL-compatible workflow and license policy for plugin projects.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
