### PR TITLE
Update Maintaining.md

### DIFF
--- a/_includes/markdown/Maintaining.md
+++ b/_includes/markdown/Maintaining.md
@@ -35,7 +35,7 @@ The following GitHub Actions are also recommended on most, if not all, projects:
 - [Deploying plugin asset/readme updates to the WordPress.org repository](https://github.com/10up/action-wordpress-plugin-asset-update) ([example](https://github.com/10up/eight-day-week/blob/develop/.github/workflows/push-asset-readme-update.yml))
 - [PHP linting without additional codebase dependencies](https://github.com/10up/wpcs-action) ([example](https://github.com/10up/classifai/blob/develop/.github/workflows/lint.yml))
 - [Publishing generated hook documentation to GitHub Pages](https://github.com/10up/actions-wordpress/blob/stable/hookdocs-workflow.md) ([example](https://github.com/10up/distributor/blob/develop/.github/workflows/build-docs.yml))
-- [No Response issue auto-closer](https://github.com/lee-dohm/no-response) ([example](https://github.com/10up/ads-txt/blob/develop/.github/workflows/no-response.yml))
+- [Stale issue auto-closer](https://github.com/actions/stale) ([example](https://github.com/10up/insert-special-characters/blob/develop/.github/workflows/close-stale-issues.yml))
 
 <h2 id="dotorg-support-reps" class="anchor-heading">WordPress.org Support {% include Util/link_anchor anchor="dotorg-support" %} {% include Util/top %}</h2>
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Replaces the no-response with stale action.  I had noticed recently that there were lots of No Response action failures, and after looking into it appears that the former action was no longer supported, throwing node 12/16 warnings, and the hope in changing to a GitHub first-party action will be improved stability (aka action runs not failing randomly) and proper node version support.

### How to test the Change
Preview via Markdown previewer

### Changelog Entry
> Changed - Replaced [lee-dohm/no-response](https://github.com/lee-dohm/no-response) with [actions/stale](https://github.com/actions/stale) to help with closing no-response/stale issues.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
