### PR TITLE
Bump WP/PHP minimum version support methods

### DIFF
--- a/_includes/markdown/Maintaining.md
+++ b/_includes/markdown/Maintaining.md
@@ -59,9 +59,9 @@ In general we follow the [Version Control guidelines from the 10up Engineering B
 
 Our defined minimum supported versions for WordPress and PHP are set as follows:
 
-- The active major version of WordPress from one year prior (e.g. when [6.0](https://wordpress.org/news/2022/05/arturo/) was released this would mean [5.7](https://wordpress.org/news/2021/03/esperanza/) is minimum supported version)
-- PHP version 7.4
+- WordPress L-2 support method where we support the current major version and the prior two major versions (e.g. when [6.0](https://wordpress.org/news/2022/05/arturo/) was released this would mean [5.8](https://wordpress.org/news/2021/03/esperanza/) is minimum supported version)
+- PHP version 8.0
 
-The WordPress minimum can be updated with each subsequent [major version release](https://wordpress.org/about/history/), noting that depending on the release velocity of the prior year that the minimum may not change or may increase by more than one version.
+The WordPress minimum should be updated with each subsequent [major version release](https://wordpress.org/about/history/), but may be increased for specific projects where fixing a bug or adding a new feature is specifically more simpler by not supporting as many WordPress versions.
 
-We expect to review the PHP minimum heading into 2023 and bump that to 8.0 (with the coming end-of-life support of 7.4 and increase in [WordPress core support for 8.0+](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/)).  PHP supported versions and end-of-life timelines can be viewed on the [PHP Supported Versions page](https://www.php.net/supported-versions).
+We expect to review the PHP minimum heading into 2025 and bump that to 8.2 (with 8.1 already in the "security only fixes" support level and increase in [WordPress core support up to 8.3](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/)).  PHP supported versions and end-of-life timelines can be viewed on the [PHP Supported Versions page](https://www.php.net/supported-versions).


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR bumps the PHP minimum from 7.4 to 8.0.  It also updates the WP support method from a trailing year for major version support to the prior to releases (aka L-2).

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Use a markdown previewer to read the updated support methods.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - WordPress and PHP minimum supported version methods.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
